### PR TITLE
Upgrade Microsoft.Band SDK, upgrade .NET Core

### DIFF
--- a/FakeBand.Tests/project.json
+++ b/FakeBand.Tests/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
-    "Microsoft.Band": "1.3.20307",
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
+    "Microsoft.Band": "1.3.20628",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "xunit": "2.2.0-beta1-build3239",
     "xunit.runner.visualstudio": "2.2.0-beta1-build1144"
   },

--- a/FakeBand/FakeBand.csproj
+++ b/FakeBand/FakeBand.csproj
@@ -107,8 +107,8 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Band, Version=1.3.20307.2, Culture=neutral, PublicKeyToken=608d7da3159f502b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Band.1.3.20307\lib\portable-net45+win+wpa81\Microsoft.Band.dll</HintPath>
+    <Reference Include="Microsoft.Band, Version=1.3.20628.2, Culture=neutral, PublicKeyToken=608d7da3159f502b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Band.1.3.20628\lib\portable-net45+win+wpa81\Microsoft.Band.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/FakeBand/Fakes/FakeBandTileManager.cs
+++ b/FakeBand/Fakes/FakeBandTileManager.cs
@@ -193,7 +193,7 @@ namespace FakeBand.Fakes
             throw new NotImplementedException();
         }
 
-        public bool TileInstalledAndOwned(ref Guid tileId, CancellationToken token)
+        public bool TileInstalledAndOwned(Guid tileId, CancellationToken token)
         {
             throw new NotImplementedException();
         }

--- a/FakeBand/packages.config
+++ b/FakeBand/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Band" version="1.3.20307" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Microsoft.Band" version="1.3.20628" targetFramework="portable45-net45+win8+wpa81" />
   <package id="Rx-Core" version="2.2.5" targetFramework="portable45-net45+win8+wpa81" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="portable45-net45+win8+wpa81" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="portable45-net45+win8+wpa81" />


### PR DESCRIPTION
Resolves #18

Test `FakeBand.Tests.TileManagerTests.TileManager_SetNewTile` still fails with:

> The application called an interface that was marshalled for a different thread. (Exception from HRESULT: 0x8001010E (RPC_E_WRONG_THREAD))

This is because testing is currently not possible involving the UI thread, and apparently `WriteableBitmap` requires the UI thread.
